### PR TITLE
Add version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This cookbook contains the following attributes:
     <th>Default</th>
   </tr>
   <tr>
+    <td><tt>['mailcatcher']['version']</tt></td>
+    <td>String</td>
+    <td>Version of the mailcatcher gem to install</td>
+    <td><tt>nil (defaults to latest version available)</tt></td>
+  </tr>
+  <tr>
     <td><tt>['mailcatcher']['mailcatcher']['name']</tt></td>
     <td>String</td>
     <td>The name of the MailCatcher binary file</td>

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,7 +32,9 @@ when 'rhel', 'fedora', 'suse'
 end
 
 # Install mailcatcher
-gem_package 'mailcatcher'
+gem_package 'mailcatcher' do
+  version node['mailcatcher']['version'] if node['mailcatcher']['version']
+end
 
 # Create init scripts for Mailcatcher daemon.
 case node['platform']


### PR DESCRIPTION
Adding the ability to specify a version of mailcatcher to install.  Attribute is optional and defaults to latest (current behavior).
